### PR TITLE
CORS and audience compatibility

### DIFF
--- a/aiohttp_jwtplus/middleware.py
+++ b/aiohttp_jwtplus/middleware.py
@@ -91,6 +91,8 @@ class JWTHelper:
         async def _router(request, handler):
             try:
 
+                if request.method.lower() == 'options':  # to enable CORS       
+                    return await handler(request)
                 if self._whitelist:
                     if check_if_request_in_whitelist(request.path , self._whitelist):
                         return await handler(request)

--- a/aiohttp_jwtplus/secrets.py
+++ b/aiohttp_jwtplus/secrets.py
@@ -8,14 +8,15 @@ import asyncio
 class SecretManager:
 
     def __init__(
-            self , 
-            secret:str = "" , 
-            refresh_interval = 0 , 
-            scheme = 'Bearer',
-            algorithm = 'HS256' , 
-            exptime = '30d'
+            self, 
+            secret:str="", 
+            refresh_interval=0, 
+            scheme='Bearer',
+            algorithm='HS256', 
+            exptime='30d',
+            audience:str=None
         ):
-        if not isinstance(secret , str):
+        if not isinstance(secret, str):
             raise TypeError("Secret should be a string.")
 
         self.algorithm = algorithm
@@ -30,6 +31,7 @@ class SecretManager:
         self._exptime = self._parse_time(exptime)
         self.scheme = scheme
         self._scheme_bytes = self.scheme.encode('utf-8')
+        self._audience = audience
 
     def _parse_time(self, interval):  
 
@@ -65,8 +67,8 @@ class SecretManager:
         rc = lambda :chr(random.randint(0,74) + 48)
         return ''.join((rc() for i in range(n)))
 
-    def decode(self , *args , **kwargs):
-        return pyjwt.decode( algorithms = [self.algorithm,] ,*args , **kwargs)
+    def decode(self, *args, **kwargs):
+        return pyjwt.decode(algorithms=[self.algorithm], audience=self._audience, *args, **kwargs)
 
     def encode(self , payload , *args , **kwargs):
         if not isinstance(payload , dict):

--- a/aiohttp_jwtplus/utils.py
+++ b/aiohttp_jwtplus/utils.py
@@ -13,7 +13,7 @@ async def basic_token_getter(request):
             return web.HTTPForbidden()
 
 async def basic_identifier(payload):
-    if 'username' in payload:
+    if 'sub' in payload:
         ret = payload['sub']  # https://en.wikipedia.org/wiki/JSON_Web_Token
         if ret:
             return {'sub' : ret , 'full_jwt_payload':payload}

--- a/aiohttp_jwtplus/utils.py
+++ b/aiohttp_jwtplus/utils.py
@@ -14,9 +14,9 @@ async def basic_token_getter(request):
 
 async def basic_identifier(payload):
     if 'username' in payload:
-        ret = payload['username']
+        ret = payload['sub']  # https://en.wikipedia.org/wiki/JSON_Web_Token
         if ret:
-            return {'username' : ret , 'full_jwt_payload':payload}
+            return {'sub' : ret , 'full_jwt_payload':payload}
     else:
         return False
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# requires for 'bs4' and 'lxml' packages 
+
 from setuptools import setup, find_packages
 from requests import get as rget
 from bs4 import BeautifulSoup
@@ -31,12 +33,13 @@ description = html.find('meta' ,{'name':'description'}).get('content')
 for kw in (' - GitHub', ' - GoodManWEN'):
     if ' - GitHub' in description:
         description = description[:description.index(' - GitHub')]
-html = BeautifulSoup(rget(release , headers).text ,'lxml')
-version = html.find('div',{'class':'release-header'}).find('a').text
+# html = BeautifulSoup(rget(release , headers).text ,'lxml')
+# version = html.find('div',{'class':'release-header'}).find('a').text
+version = '0.2.1'  # makes this code working
 logger.info(f"description: {description}")
 logger.info(f"version: {version}")
 
-#
+#version
 with open('README.md','r',encoding='utf-8') as f:
     long_description_lines = f.readlines()
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@
 from setuptools import setup, find_packages
 from requests import get as rget
 from bs4 import BeautifulSoup
-import logging , sys
+import logging, sys
+
+VERSION = '0.2.1'  # Setup script should work for any branch, not for releases. Usually, the version in repo is the lattest and not released
+
 # init logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -20,7 +23,6 @@ def get_install_requires(filename):
 
 # 
 url = 'https://github.com/GoodManWEN/aiohttp-jwtplus'
-release = f'{url}/releases/latest'
 headers = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36",
     "Connection": "keep-alive",
@@ -33,9 +35,7 @@ description = html.find('meta' ,{'name':'description'}).get('content')
 for kw in (' - GitHub', ' - GoodManWEN'):
     if ' - GitHub' in description:
         description = description[:description.index(' - GitHub')]
-# html = BeautifulSoup(rget(release , headers).text ,'lxml')
-# version = html.find('div',{'class':'release-header'}).find('a').text
-version = '0.2.1'  # makes this code working
+version = VERSION
 logger.info(f"description: {description}")
 logger.info(f"version: {version}")
 


### PR DESCRIPTION
OPTIONS requests are passed without authorization to make CORS working.
Added 'audience' parameter into Secret to enable decoded JWT check via 'aud' field.
Replaced 'username' field check with 'sub' field check for decoded JWT (see Wikipedia).
Fixed setup.py to enable installation in this manner: pip install git+https://github.com/GoodManWEN/aiohttp-jwtplus.git

Please, release the latest version to PYPI.